### PR TITLE
Initial implementation of SUSP entries and Rock Ridge protocol

### DIFF
--- a/isoparser/iso.py
+++ b/isoparser/iso.py
@@ -66,9 +66,12 @@ class ISO(object):
         # Resolve the remainder of the path by walking record children
         for part in path[pivot:]:
             for child in record.children_unsafe:
+                # Must save the cursor since child.name can cause a seek
+                saved_cursor = self._source.save_cursor()
                 if child.name == part:
                     record = child
                     break
+                self._source.restore_cursor(saved_cursor)
             else:
                 raise KeyError(part)
 

--- a/isoparser/record.py
+++ b/isoparser/record.py
@@ -1,5 +1,8 @@
+import susp
+import rockridge
+
 class Record(object):
-    def __init__(self, source, length):
+    def __init__(self, source, length, susp_starting_index=None):
         self._source = source
         self._content = None
         target = source.cursor + length
@@ -16,17 +19,112 @@ class Record(object):
         _                  = source.unpack('B')       # TODO: interleave gap size
         _                  = source.unpack_both('h')  # TODO: volume sequence
         name_length        = source.unpack('B')
-        self.name          = source.unpack_string(name_length).split(';')[0]
-        if self.name == "\x00":
-            self.name = ""
+        self.raw_name      = source.unpack_string(name_length).split(';')[0]
+        if self.raw_name == "\x00":
+            self.raw_name = ""
+        if name_length % 2 == 0:
+            source.unpack_raw(1) # Parity padding
 
-        # TODO: extended attributes
+        # System-use area
+        susp_entries = []
+        if susp_starting_index is None:
+            try_susp = source.unpack_susp(target - source.cursor)
+            if isinstance(try_susp, susp.SP):
+                susp_entries.append(try_susp)
+                if try_susp.len_skp > 7:
+                    susp_starting_index = try_susp.len_skp - 7
+
+        if susp_starting_index is not False:
+            if susp_starting_index:
+                source.unpack_raw(susp_starting_index)
+            while True:
+                try_susp = source.unpack_susp(target - source.cursor)
+                if not try_susp:
+                    break
+                susp_entries.append(try_susp)
+                if isinstance(try_susp, susp.ST):
+                    # "Stop" entry
+                    break
+
+        self.embedded_susp_entries = susp_entries
+
+        assert source.cursor <= target
         source.unpack_raw(target - source.cursor)
 
     def __repr__(self):
         return "<Record (%s) name=%r>" % (
             "directory" if self.is_directory else "file",
             self.name)
+
+    @property
+    def name(self):
+        name = ""
+        for entry in self.susp_entries_unsafe:
+            if not isinstance(entry, rockridge.NM):
+                continue
+            name += entry.name
+            if entry.flags & rockridge.NM.CONTINUE == 0:
+                break
+        return name or self.raw_name
+
+    @property
+    def susp_entries_unsafe(self):
+        """
+        This generator yields a record for each SUSP entry associated with this record. As with
+        children_unsafe, the generator assumes that the source cursor has not moved since the
+        previous child was yielded. For safer behaviour, use :func:`susp_entries`.
+        """
+
+        embedded_iter = iter(self.embedded_susp_entries)
+        target = None
+        ce_entry = None
+        while embedded_iter or target or ce_entry:
+            if embedded_iter:
+                try:
+                    entry = embedded_iter.next()
+                except StopIteration:
+                    entry = None
+                    embedded_iter = None
+                    continue
+            elif target:
+                entry = self._source.unpack_susp(target - self._source.cursor)
+                if not entry:
+                    target = None
+                    continue
+            elif ce_entry:
+                self._source.seek(ce_entry.location, ce_entry.offset + ce_entry.length)
+                self._source.unpack_raw(ce_entry.offset)
+                target = self._source.cursor + ce_entry.length
+                ce_entry = None
+                continue
+
+            yield entry
+
+            if isinstance(entry, susp.ST):
+                # "Stop" entry; continue from next CE, if available
+                embedded_iter = None
+                target = None
+            elif isinstance(entry, susp.CE):
+                ce_entry = entry
+
+    @property
+    def susp_entries(self):
+        """
+        This property is a list of all SUSP entries associated with this record.
+        """
+        return list(self.susp_entries_unsafe)
+
+    def find_susp_entry(self, entryclass, condition=None):
+        """
+        This method returns the first SUSP entry of the specified class (which must be a subclass
+        of susp.SUSP_Entry) meeting an optional condition, or None if no entry was found.
+        """
+        assert issubclass(entryclass, susp.SUSP_Entry)
+        for entry in self.susp_entries_unsafe:
+            if isinstance(entry, entryclass):
+                if not condition or condition(entry):
+                    return entry
+        return None
 
     @property
     def children_unsafe(self):
@@ -54,6 +152,27 @@ class Record(object):
         Assuming this is a directory record, this property contains records for its children.
         """
         return list(self.children_unsafe)
+
+    @property
+    def current_directory(self):
+        """
+        Assuming this is a directory record, this property returns the directory entry for the
+        current directory ("." in Unix parlance, "" in ISO9660).
+        """
+        assert self.is_directory
+        self._source.seek(self.location, self.length)
+        return self._source.unpack_record()  # current directory
+
+    @property
+    def parent_directory(self):
+        """
+        Assuming this is a directory record, this property returns the directory entry for the
+        parent directory (".." in Unix parlance, "\\x01" in ISO9660).
+        """
+        assert self.is_directory
+        self._source.seek(self.location, self.length)
+        _ = self._source.unpack_record()  # current directory
+        return self._source.unpack_record()  # parent directory
 
     @property
     def content(self):

--- a/isoparser/rockridge.py
+++ b/isoparser/rockridge.py
@@ -1,0 +1,167 @@
+from susp import SUSP_Entry, susp_assert
+
+RRIP_109 = ('RRIP_1991A', 1)
+RRIP_112 = ('IEEE_P1282', 1)
+
+EXT_VERSIONS = (RRIP_109, RRIP_112)
+
+class RR(SUSP_Entry):
+    _implements = [
+        RRIP_109 + ('RR', 1),
+    ]
+
+    PX = 1
+    PN = 2
+    SL = 4
+    NM = 8
+    CL = 16
+    PL = 32
+    RE = 64
+    TF = 128
+
+    _repr_props = ('flags',)
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(RR, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length == 1)
+        self.flags = source.unpack('B')
+
+class PX(SUSP_Entry):
+    _implements = [
+        RRIP_109 + ('PX', 1),
+        RRIP_112 + ('PX', 1),
+    ]
+
+    _repr_props = ('mode','nlinks','uid','gid')
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(PX, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length == (40 if ext_id_ver == RRIP_112 else 32))
+        self.mode   = source.unpack_both('I')
+        self.nlinks = source.unpack_both('I')
+        self.uid    = source.unpack_both('I')
+        self.gid    = source.unpack_both('I')
+        self.ino    = source.unpack_both('I') if ext_id_ver == RRIP_112 else None
+
+class PN(SUSP_Entry):
+    _implements = [
+        RRIP_109 + ('PN', 1),
+        RRIP_112 + ('PN', 1),
+    ]
+
+    _repr_props = ('dev_high', 'dev_low')
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(PN, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length == 16)
+        self.dev_high = source.unpack_both('I')
+        self.dev_low  = source.unpack_both('I')
+
+class SL(SUSP_Entry):
+    _implements = [
+        RRIP_109 + ('SL', 1),
+        RRIP_112 + ('SL', 1),
+    ]
+
+    CONTINUE = 1
+    CURRENT  = 2
+    PARENT   = 4
+    ROOT     = 8
+
+    _repr_props = ('flags', 'path')
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(SL, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length >= 2) # Needs SL flags and at least one component
+        target = source.cursor + length
+        self.flags = source.unpack('B')
+        self.path = ""
+        while source.cursor < target:
+            comp_flags   = source.unpack('B')
+            comp_len     = source.unpack('B')
+            comp_content = source.unpack_raw(comp_len)
+            susp_assert(source.cursor <= target)
+            if comp_flags == SL.CURRENT:
+                susp_assert(comp_len == 0)
+                self.path += "."
+            elif comp_flags == SL.PARENT:
+                susp_assert(comp_len == 0)
+                self.path += ".."
+            elif comp_flags == SL.ROOT:
+                susp_assert(comp_len == 0)
+            elif comp_flags in (0, SL.CONTINUE):
+                susp_assert(comp_len > 0)
+                self.path += comp_content
+            else:
+                susp_assert(False) # Unknown SL flags
+
+            if comp_flags == SL.CONTINUE:
+                # If this is a root component or an unfinished component, don't append a /
+                pass
+            elif comp_flags == 0 and source.cursor == target and (self.flags & SL.CONTINUE == 0):
+                # If this is the last component in the link, don't append a /
+                pass
+            else:
+                # Otherwise, append a /
+                self.path += "/"
+
+class NM(SUSP_Entry):
+    _implements = [
+        RRIP_109 + ('NM', 1),
+        RRIP_112 + ('NM', 1),
+    ]
+
+    _repr_props = ('flags', 'name')
+
+    CONTINUE = 1
+    CURRENT  = 2
+    PARENT   = 4
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(NM, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length >= 1)
+        self.flags = source.unpack('B')
+        name_content = source.unpack_raw(length - 1)
+        if self.flags == NM.CURRENT:
+            susp_assert(length == 1)
+            self.name = "."
+        elif self.flags == NM.PARENT:
+            susp_assert(length == 1)
+            self.name = ".."
+        elif self.flags in (0, NM.CONTINUE):
+            susp_assert(length > 1)
+            self.name = name_content
+
+class TF(SUSP_Entry):
+    _implements = [
+        RRIP_109 + ('TF', 1),
+        RRIP_112 + ('TF', 1),
+    ]
+
+    _repr_props = ('flags', 'creation', 'modify', 'access', 'attributes', 'backup', 'expiration', 'effective')
+
+    CREATION   = 1
+    MODIFY     = 2
+    ACCESS     = 4
+    ATTRIBUTES = 8
+    BACKUP     = 16
+    EXPIRATION = 32
+    EFFECTIVE  = 64
+    LONG_FORM  = 128
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(TF, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length >= 1)
+        self.flags = source.unpack('B')
+        if self.flags & TF.LONG_FORM:
+            unpack_datetime = source.unpack_vd_datetime
+        else:
+            unpack_datetime = source.unpack_dir_datetime
+
+        self.creation   = unpack_datetime() if self.flags & TF.CREATION else None
+        self.modify     = unpack_datetime() if self.flags & TF.MODIFY else None
+        self.access     = unpack_datetime() if self.flags & TF.ACCESS else None
+        self.attributes = unpack_datetime() if self.flags & TF.ATTRIBUTES else None
+        self.backup     = unpack_datetime() if self.flags & TF.BACKUP else None
+        self.expiration = unpack_datetime() if self.flags & TF.EXPIRATION else None
+        self.effective  = unpack_datetime() if self.flags & TF.EFFECTIVE else None

--- a/isoparser/rockridge.py
+++ b/isoparser/rockridge.py
@@ -36,12 +36,12 @@ class PX(SUSP_Entry):
 
     def __init__(self, source, ext_id_ver, sig_version, length):
         super(PX, self).__init__(source, ext_id_ver, sig_version, length)
-        susp_assert(length == (40 if ext_id_ver == RRIP_112 else 32))
+        susp_assert(length in (32, 40))
         self.mode   = source.unpack_both('I')
         self.nlinks = source.unpack_both('I')
         self.uid    = source.unpack_both('I')
         self.gid    = source.unpack_both('I')
-        self.ino    = source.unpack_both('I') if ext_id_ver == RRIP_112 else None
+        self.ino    = source.unpack_both('I') if length >= 40 else None
 
 class PN(SUSP_Entry):
     _implements = [

--- a/isoparser/source.py
+++ b/isoparser/source.py
@@ -179,6 +179,12 @@ class Source(object):
 
         self._buff = self._buff[:length]
 
+    def save_cursor(self):
+        return (self._buff, self.cursor)
+
+    def restore_cursor(self, cursor_def):
+        self._buff, self.cursor = cursor_def
+
     def _fetch(self, sector, count=1):
         raise NotImplementedError
 

--- a/isoparser/source.py
+++ b/isoparser/source.py
@@ -5,6 +5,7 @@ import urllib
 import path_table
 import record
 import volume_descriptors
+import susp
 
 
 SECTOR_LENGTH = 2048
@@ -21,9 +22,17 @@ class Source(object):
         self.cursor = None
         self.cache_content = cache_content
         self.min_fetch = min_fetch
+        self.susp_starting_index = None
+        self.susp_extensions = []
+        self.rockridge = False
 
     def __len__(self):
         return len(self._buff) - self.cursor
+
+    def rewind_raw(self, l):
+        if self.cursor < l:
+            raise SourceError("Rewind buffer under-run")
+        self.cursor -= l
 
     def unpack_raw(self, l):
         if l > len(self):
@@ -56,6 +65,9 @@ class Source(object):
             return d[0]
         else:
             return d
+
+    def rewind(self, st):
+        self.rewind_raw(struct.calcsize(st))
 
     def unpack_vd_datetime(self):
         return self.unpack_raw(17)  # TODO
@@ -100,10 +112,40 @@ class Source(object):
         return path_table.PathTable(self)
 
     def unpack_record(self):
+        start_cursor = self.cursor
         length = self.unpack('B')
         if length == 0:
+            self.rewind('B')
             return None
-        return record.Record(self, length-1)
+        new_record = record.Record(self, length-1, self.susp_starting_index)
+        assert self.cursor == start_cursor + length
+        return new_record
+
+    def unpack_susp(self, maxlen, possible_extension=0):
+        if maxlen < 4:
+            return None
+        start_cursor = self.cursor
+        signature = self.unpack_raw(2)
+        length = self.unpack('B')
+        version = self.unpack('B')
+        if maxlen < length:
+            self.rewind_raw(4)
+            return None
+        if possible_extension < len(self.susp_extensions):
+            extension = self.susp_extensions[possible_extension]
+            ext_id_ver = (extension.ext_id, extension.ext_ver)
+        else:
+            ext_id_ver = None
+        try:
+            new_susp = susp.SUSP_Entry.unpack(self, ext_id_ver, (signature, version), length - 4)
+        except susp.SUSPError:
+            self.cursor = start_cursor
+            # Fall into the next if statement
+        if self.cursor != start_cursor + length:
+            self.cursor = start_cursor + 4
+            new_susp = susp.UnknownEntry(self, ext_id_ver, (signature, version), length - 4)
+        assert self.cursor == start_cursor + length
+        return new_susp
 
     def seek(self, start_sector, length=SECTOR_LENGTH, is_content=False):
         self.cursor = 0

--- a/isoparser/susp.py
+++ b/isoparser/susp.py
@@ -1,0 +1,132 @@
+class SUSPError(Exception):
+    pass
+
+def susp_assert(condition):
+    if not condition:
+        raise SUSPError("Failed SUSP assertion")
+
+class susp_meta(type):
+    def __new__(mcs, name, bases, dict):
+        cls = type.__new__(mcs, name, bases, dict)
+        if '_implements' in dict:
+            for i in dict['_implements']:
+                SUSP_Entry._registered_classes[i] = cls
+        return cls
+
+class SUSP_Entry(object):
+    _registered_classes = {}
+    __metaclass__ = susp_meta
+    _repr_props = ()
+
+    @classmethod
+    def unpack(cls, source, ext_id_ver, sig_version, length):
+        implementing_class = None
+        if ext_id_ver:
+            implementing_class = cls._registered_classes.get(ext_id_ver + sig_version)
+        if not implementing_class:
+            ext_id_ver = None
+            implementing_class = cls._registered_classes.get(sig_version, UnknownEntry)
+        return implementing_class(source, ext_id_ver, sig_version, length)
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        self.ext_id_ver = ext_id_ver
+        self.sig_version = sig_version
+        self.signature, self.version = sig_version
+
+    def __repr__(self):
+        return "<SUSP (%s,%d)%s>" % (
+            self.signature, self.version,
+            ''.join(" %s=%s" % (k,repr(v)) for k,v in self._repr_keyvals))
+
+    @property
+    def _repr_keyvals(self):
+        for prop in self._repr_props:
+            yield prop, getattr(self, prop)
+
+class UnknownEntry(SUSP_Entry):
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(UnknownEntry, self).__init__(source, ext_id_ver, sig_version, length)
+        self.unknown_raw = source.unpack_raw(length)
+
+    @property
+    def _repr_keyvals(self):
+        return {'unknown/length':len(self.unknown_raw)+4}.iteritems()
+
+class SP(SUSP_Entry):
+    _implements = [
+        ('SP', 1),
+    ]
+
+    _repr_props = ('len_skp',)
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(SP, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length == 3)
+        susp_assert(source.unpack_raw(2) == "\xbe\xef")
+        self.len_skp = source.unpack('B')
+
+class CE(SUSP_Entry):
+    _implements = [
+        ('CE', 1),
+    ]
+
+    _repr_props = ('location', 'offset', 'length')
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(CE, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length == 24)
+        self.location = source.unpack_both('I')
+        self.offset   = source.unpack_both('I')
+        self.length   = source.unpack_both('I')
+
+class PD(SUSP_Entry):
+    _implements = [
+        ('PD', 1),
+    ]
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(PD, self).__init__(source, ext_id_ver, sig_version, length)
+        if length:
+            source.unpack_raw(length) # Padding, ignored
+
+class ST(SUSP_Entry):
+    _implements = [
+        ('ST', 1),
+    ]
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(ST, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length == 0)
+
+class ER(SUSP_Entry):
+    _implements = [
+        ('ER', 1),
+    ]
+
+    _repr_props = ('ext_id', 'ext_ver')
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(ER, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length >= 4)
+        len_id  = source.unpack('B')
+        len_des = source.unpack('B')
+        len_src = source.unpack('B')
+        susp_assert(length == 4 + len_id + len_des + len_src)
+        self.ext_ver = source.unpack('B')
+        self.ext_id  = source.unpack_raw(len_id)
+        self.ext_des = source.unpack_raw(len_des)
+        self.ext_src = source.unpack_raw(len_src)
+
+class ES(SUSP_Entry):
+    _implements = [
+        ('ES', 1),
+    ]
+
+    _repr_props = ('ext_seq',)
+
+    def __init__(self, source, ext_id_ver, sig_version, length):
+        super(ER, self).__init__(source, ext_id_ver, sig_version, length)
+        susp_assert(length == 1)
+        self.ext_seq = source.unpack('B')
+
+import rockridge


### PR DESCRIPTION
This is a fairly comprehensive implementation of SUSP, a mostly-complete
implementation of RRIP, and a rudimentary integration into the existing
isoparser structure. Features implemented:
- An extensible SUSP parser with full support for SUSP extensions,
  including proper extension name matching. Probably overkill; the Linux
  kernel itself doesn't bother matching extension IDs, it just assumes
  that no extensions will conflict with Rock Ridge. Which is probably a
  reasonable assumption.
- Support for the following Rock Ridge features: NM (alternate name), TF
  (file timestamps), SL (symlink targets), PX (posix stats), and PN
  (device major/minor).
- isofile.Record will now report the Rock Ridge name if available, and
  iso.record() will search on Rock Ridge names.

To do:
- Support more Rock Ridge properties in the Record class, especially
  symlink targets.
- Support deep directory hierarchies (the CL/PL/RE entries).
