### PR TITLE
travis-ci integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idea
+*.swp
+*.ropeproject
 *.pyc
 build
+.tox
+isoparser.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  # PyPy versions
+  - "pypy"
+  - "jython"
+# command to install dependencies
+install:
+  - pip install .
+  - pip install tox-travis
+# command to run tests
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"
@@ -8,7 +7,6 @@ python:
   - "3.5"
   # PyPy versions
   - "pypy"
-  - "jython"
 # command to install dependencies
 install:
   - pip install .

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
 isoparser
 =========
+.. image:: https://travis-ci.org/zeroos/isoparser.svg?branch=master
+    :target: https://travis-ci.org/zeroos/isoparser
 
 This python library can parse the `ISO 9660`_ disk image format including
 `Rock Ridge`_ extensions. It can load ISOs from the local filesystem or via

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 isoparser
 =========
-.. image:: https://travis-ci.org/zeroos/isoparser.svg?branch=master
-    :target: https://travis-ci.org/zeroos/isoparser
+.. image:: https://travis-ci.org/barneygale/isoparser.svg?branch=master
+    :target: https://travis-ci.org/barneygale/isoparser
 
 This python library can parse the `ISO 9660`_ disk image format including
 `Rock Ridge`_ extensions. It can load ISOs from the local filesystem or via

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from distutils.core import setup
+from setuptools import setup
+
 
 setup(
     name='isoparser',
@@ -9,4 +10,6 @@ setup(
     license='MIT',
     description='Parser for the ISO 9660 disk image format',
     packages=["isoparser"],
+    install_requires=["six"],
+    test_suite="isoparser.test",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, pypy, jython
+envlist = py27, py32, py33, py34, py35, pypy
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py32, py33, py34, py35, pypy, jython
+
+[testenv]
+commands = {envpython} setup.py test
+deps = 
+


### PR DESCRIPTION
Hey,

I have integrated the project with travis-ci. If you are not familiar with Travis (as I was), you just need to log in at http://travis-ci.org and enable isoparser in your profile. Unfortunately the code is not working on Python 2.6, but I guess if  someone wants to use it, he would port it easily.

If it is OK, could you please release it on PyPI?

Hope you like it!
Michał