### PR TITLE
I'm adding the dependency to six on the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='isoparser',
@@ -8,5 +8,6 @@ setup(
     url='https://github.com/barneygale/isoparser',
     license='MIT',
     description='Parser for the ISO 9660 disk image format',
+    install_requires=['six'],
     packages=["isoparser"],
 )


### PR DESCRIPTION
If you install this project without six installed, you can't import
isoparser. To fix this, I've changed distutils to setuptools to
add the install_requires parameter.