### PR TITLE
Fix: source.FileStream to process directly file streams

### DIFF
--- a/isoparser/source.py
+++ b/isoparser/source.py
@@ -195,8 +195,9 @@ class Source(object):
         pass
 
 
-class FileStream(object):
+class FileStream(Source):
     def __init__(self, file, offset, length):
+        super(FileStream, self).__init__()
         self._file = file
         self._offset = offset
         self._length = length
@@ -211,6 +212,10 @@ class FileStream(object):
         if data:
             self.cur_offset += len(data)
         return data
+
+    def _fetch(self, sector, count=1):
+        self._file.seek(sector*SECTOR_LENGTH)
+        return self._file.read(SECTOR_LENGTH*count)
 
     def close(self):
         pass


### PR DESCRIPTION
Currently if you use FileStream with an already open file stream fails, this patch allow you to use it.  Example:

```python
raw_iso9660 = open('iso', 'rb')
raw_iso9660.seek(-1)
size = raw_iso9660.tell()

file_stream = isoparser.source.FileStream(raw_iso9660, 0, size)
iso = isoparser.iso.ISO(file_stream)

print iso
print iso.record().children
```