### PR TITLE
Fix bug #20: support both legacy strings and unicode strings in iso.record()

### DIFF
--- a/isoparser/iso.py
+++ b/isoparser/iso.py
@@ -1,3 +1,5 @@
+import six
+
 from . import susp, rockridge
 
 
@@ -50,6 +52,9 @@ class ISO(object):
         """
         Retrieves a record for the given path.
         """
+        # Path must be converted to binary string as same as the path table before lookup
+        path = [part if isinstance(part, six.binary_type) else part.encode() for part in path]
+
         record = None
         if self._source.rockridge:
             # In Rock Ridge mode, we can't use the path table


### PR DESCRIPTION
This fix implemented a 2-3 compatible way to support both legacy strings and unicode strings as path argument in method iso.record().